### PR TITLE
Add --clean to reset all repos to upstream master

### DIFF
--- a/bin/prep_source_repos
+++ b/bin/prep_source_repos
@@ -40,6 +40,9 @@ def normalise_conf(conf):
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--clean", help="If set, reset each repo to upstream "
+                        "state with no patches applied (ignoring refs in "
+                        "config file)", action='store_true')
     parser.add_argument("refs", help="the yaml config file")
     parser.add_argument("output", help="where to put the downloaded repositories")
     parser.add_argument("repos", help="what repos to update", nargs="*")
@@ -65,7 +68,10 @@ def main():
         if not os.path.isdir(os.path.join(rd)):
             check_call(['git', 'clone', remote, rd])
 
-        refs = CONF['gerrit_refs'].get(repo, ())
+        if args.clean:
+            refs = []
+        else:
+            refs = CONF['gerrit_refs'].get(repo, ())
 
         git_refs = ['+master:review/master']
         for ref in refs:


### PR DESCRIPTION
prep_source_repos already does a great job of applying a series of
patches - but sometimes you just want to temporarily set all the repos
back to their upstream state just to check how that's working today.

This change adds a --clean option which resets all the repos back to
upstream master state.
