### PR TITLE
Enable use inside a virtualenv

### DIFF
--- a/bin/prep_source_repos
+++ b/bin/prep_source_repos
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse
 import json


### PR DESCRIPTION
Hard-coding the path to the interpreter causes problems when running
inside a virtualenv - eg, if pyyaml is installed inside the virtualenv
but not in the system python, this will give an import error rather than
finding the virtualenv's version of pyyaml
